### PR TITLE
fix: trainer group/agent visibility in group assignment and coaching modal

### DIFF
--- a/components/CreateCoachingModal.tsx
+++ b/components/CreateCoachingModal.tsx
@@ -76,8 +76,7 @@ const CreateCoachingModal: React.FC<CreateCoachingModalProps> = ({ onClose, edit
     // ── Derived data ─────────────────────────────────────────────────────────
     const availableGroups = React.useMemo(() => {
         if (!currentUser) return [];
-        if (isAdmin || isMasterTrainer) return groups;
-        if (isTrainer) return groups.filter(g => currentUser.managedGroupIds?.includes(g.id));
+        if (isAdmin || isMasterTrainer || isTrainer) return groups;
         if (isGroupLeader) return groups.filter(g => g.id === currentUser.group_id);
         return [];
     }, [currentUser, groups, isAdmin, isMasterTrainer, isTrainer, isGroupLeader]);
@@ -85,8 +84,7 @@ const CreateCoachingModal: React.FC<CreateCoachingModalProps> = ({ onClose, edit
     const availableAgents = React.useMemo(() => {
         if (!currentUser) return [];
         const isParticipantRole = (u: User) => u.role === UserRole.AGENT || u.role === UserRole.GROUP_LEADER;
-        if (isAdmin || isMasterTrainer) return users.filter(isParticipantRole);
-        if (isTrainer) return users.filter(u => isParticipantRole(u) && currentUser.managedGroupIds?.includes(u.group_id || ''));
+        if (isAdmin || isMasterTrainer || isTrainer) return users.filter(isParticipantRole);
         if (isGroupLeader) return users.filter(u => isParticipantRole(u) && u.group_id === currentUser.group_id);
         return [];
     }, [currentUser, users, isAdmin, isMasterTrainer, isTrainer, isGroupLeader]);

--- a/pages/AdminGroups.tsx
+++ b/pages/AdminGroups.tsx
@@ -43,7 +43,8 @@ const AdminGroups: React.FC = () => {
       apiCall('/users').catch(() => ({ data: [] })),
     ]);
     setGroups(Array.isArray(groupsRes.data) ? groupsRes.data : []);
-    setUsers(Array.isArray(usersRes.data) ? usersRes.data : []);
+    const rawUsers = Array.isArray(usersRes.data) ? usersRes.data : [];
+    setUsers(rawUsers.map((u: any) => ({ ...u, managedGroupIds: u.managed_group_ids ?? [] })));
   };
 
   useEffect(() => { fetchData(); }, []);


### PR DESCRIPTION
## Summary
- **AdminGroups**: normalize `managed_group_ids → managedGroupIds` when fetching users from `GET /users`, so trainer checkboxes correctly pre-check in the Edit Group Assignment modal
- **CreateCoachingModal**: remove client-side `managedGroupIds` filtering for trainers — backend RLS already scopes `GET /groups` and `GET /users` to the trainer's managed groups, so the frontend was filtering against stale/empty data and showing nothing

## Root causes
1. `GET /users` returns snake_case `managed_group_ids`, but `AdminGroups.tsx` stored the raw response and later accessed camelCase `managedGroupIds` → always `undefined`
2. `CreateCoachingModal` filtered trainer's available groups/agents using `currentUser.managedGroupIds` (from `/auth/me`) which may not include `managed_group_ids` — backend RLS is the correct source of truth

## Test plan
- [x] Log in as trainer → open Edit Group Assignment → previously assigned groups should be pre-checked
- [x] Log in as trainer → open Create Coaching/Training Session → managed groups and their agents should appear in participant selection
🤖 Generated with [Claude Code](https://claude.com/claude-code)