### PR TITLE
feat: consolidate seminar coaching types into single 'seminar' value

### DIFF
--- a/components/CreateCoachingModal.tsx
+++ b/components/CreateCoachingModal.tsx
@@ -19,11 +19,10 @@ type FrontendType = 'individual_coaching' | 'group_coaching' | 'seminar';
 const FRONTEND_TO_BACKEND: Record<FrontendType, CoachingType> = {
     individual_coaching: 'individual_coaching',
     group_coaching: 'group_coaching',
-    seminar: '2_full_days_seminar',
+    seminar: 'seminar',
 };
 
 const backendToFrontend = (type: CoachingType): FrontendType => {
-    if (type === '2_full_days_seminar' || type === '2_hours_online_seminar') return 'seminar';
     if (type === 'peer_circles') return 'individual_coaching';
     return type as FrontendType;
 };
@@ -59,8 +58,6 @@ const CreateCoachingModal: React.FC<CreateCoachingModalProps> = ({ onClose, edit
     const [sessionType, setSessionType] = useState<FrontendType>(
         editSession ? backendToFrontend(editSession.coaching_type) : 'individual_coaching'
     );
-    const isSeminar = sessionType === 'seminar';
-
     // ── Basic fields ──────────────────────────────────────────────────────────
     const [title, setTitle] = useState(editSession?.title || '');
     const [description, setDescription] = useState(editSession?.description || '');

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4329,8 +4329,7 @@ components:
         - individual_coaching
         - group_coaching
         - peer_circles
-        - 2_full_days_seminar
-        - 2_hours_online_seminar
+        - seminar
       example: group_coaching
 
     TrainingModeEnum:

--- a/pages/AdminRewards.tsx
+++ b/pages/AdminRewards.tsx
@@ -10,7 +10,7 @@ import { DEFAULT_POINT_CONFIG } from '../services/points';
 import { apiCall } from '../services/apiClient';
 
 type ProspectActivityKey = 'prospect_created' | 'appointment_set' | 'sales_meeting' | 'sale_closed';
-type CoachingActivityKey = 'coaching_individual_attended' | 'coaching_group_attended' | 'coaching_peer_circles_attended' | 'coaching_2_full_days_attended' | 'coaching_2_hours_online_attended';
+type CoachingActivityKey = 'coaching_individual_attended' | 'coaching_group_attended' | 'coaching_peer_circles_attended' | 'coaching_seminar_attended';
 type ActivityKey = ProspectActivityKey | CoachingActivityKey;
 
 const ACTIVITY_TO_FIELD: Record<ActivityKey, keyof PointConfig> = {
@@ -21,8 +21,7 @@ const ACTIVITY_TO_FIELD: Record<ActivityKey, keyof PointConfig> = {
   coaching_individual_attended: 'coachingIndividual',
   coaching_group_attended: 'coachingGroup',
   coaching_peer_circles_attended: 'coachingPeerCircles',
-  coaching_2_full_days_attended: 'coachingFullDays',
-  coaching_2_hours_online_attended: 'coachingOnlineSeminar',
+  coaching_seminar_attended: 'coachingSeminar',
 };
 
 const FIELD_TO_ACTIVITY: Partial<Record<keyof PointConfig, ActivityKey>> = {
@@ -33,8 +32,7 @@ const FIELD_TO_ACTIVITY: Partial<Record<keyof PointConfig, ActivityKey>> = {
   coachingIndividual: 'coaching_individual_attended',
   coachingGroup: 'coaching_group_attended',
   coachingPeerCircles: 'coaching_peer_circles_attended',
-  coachingFullDays: 'coaching_2_full_days_attended',
-  coachingOnlineSeminar: 'coaching_2_hours_online_attended',
+  coachingSeminar: 'coaching_seminar_attended',
 };
 
 const AdminRewards: React.FC = () => {
@@ -55,12 +53,11 @@ const AdminRewards: React.FC = () => {
   const [savedProspectPoints, setSavedProspectPoints] = useState({ ...prospectPoints });
 
   // Personal Development (Coaching) — from API
-  const [coachingPoints, setCoachingPoints] = useState<Pick<PointConfig, 'coachingIndividual' | 'coachingGroup' | 'coachingPeerCircles' | 'coachingFullDays' | 'coachingOnlineSeminar'>>({
+  const [coachingPoints, setCoachingPoints] = useState<Pick<PointConfig, 'coachingIndividual' | 'coachingGroup' | 'coachingPeerCircles' | 'coachingSeminar'>>({
     coachingIndividual: DEFAULT_POINT_CONFIG.coachingIndividual,
     coachingGroup: DEFAULT_POINT_CONFIG.coachingGroup,
     coachingPeerCircles: DEFAULT_POINT_CONFIG.coachingPeerCircles,
-    coachingFullDays: DEFAULT_POINT_CONFIG.coachingFullDays,
-    coachingOnlineSeminar: DEFAULT_POINT_CONFIG.coachingOnlineSeminar,
+    coachingSeminar: DEFAULT_POINT_CONFIG.coachingSeminar,
   });
   const [savedCoachingPoints, setSavedCoachingPoints] = useState({ ...coachingPoints });
 
@@ -110,8 +107,7 @@ const AdminRewards: React.FC = () => {
     coachingPoints.coachingIndividual !== savedCoachingPoints.coachingIndividual ||
     coachingPoints.coachingGroup !== savedCoachingPoints.coachingGroup ||
     coachingPoints.coachingPeerCircles !== savedCoachingPoints.coachingPeerCircles ||
-    coachingPoints.coachingFullDays !== savedCoachingPoints.coachingFullDays ||
-    coachingPoints.coachingOnlineSeminar !== savedCoachingPoints.coachingOnlineSeminar;
+    coachingPoints.coachingSeminar !== savedCoachingPoints.coachingSeminar;
 
   const handleUpdateProspectPoint = (key: keyof typeof prospectPoints, value: number) => {
     setProspectPoints(prev => ({ ...prev, [key]: value }));
@@ -204,8 +200,7 @@ const AdminRewards: React.FC = () => {
     { key: 'coachingIndividual', label: 'Individual Coaching' },
     { key: 'coachingGroup', label: 'Group Coaching' },
     { key: 'coachingPeerCircles', label: 'Peer Circles' },
-    { key: 'coachingFullDays', label: '2 Full Days Seminar' },
-    { key: 'coachingOnlineSeminar', label: '2 Hours Online Seminar' },
+    { key: 'coachingSeminar', label: 'Seminar' },
   ];
 
   return (
@@ -344,7 +339,7 @@ const AdminRewards: React.FC = () => {
         </div>
 
         <div className="px-6 py-3 bg-gray-50 border-t text-xs text-gray-500">
-          Defaults — Prospect: info +{DEFAULT_POINT_CONFIG.prospectBasicInfo} · appt +{DEFAULT_POINT_CONFIG.appointmentCompleted} · meeting +{DEFAULT_POINT_CONFIG.salesMeetingCompleted} · sale +{DEFAULT_POINT_CONFIG.salesSuccessful} · Sales: cert +{DEFAULT_POINT_CONFIG.salesIssuanceCertificate} · FYCt +{DEFAULT_POINT_CONFIG.salesFYCt} · ACE +{DEFAULT_POINT_CONFIG.salesACE} · Coaching: +{DEFAULT_POINT_CONFIG.coachingIndividual}/{DEFAULT_POINT_CONFIG.coachingFullDays} pts
+          Defaults — Prospect: info +{DEFAULT_POINT_CONFIG.prospectBasicInfo} · appt +{DEFAULT_POINT_CONFIG.appointmentCompleted} · meeting +{DEFAULT_POINT_CONFIG.salesMeetingCompleted} · sale +{DEFAULT_POINT_CONFIG.salesSuccessful} · Sales: cert +{DEFAULT_POINT_CONFIG.salesIssuanceCertificate} · FYCt +{DEFAULT_POINT_CONFIG.salesFYCt} · ACE +{DEFAULT_POINT_CONFIG.salesACE} · Coaching: +{DEFAULT_POINT_CONFIG.coachingIndividual}/{DEFAULT_POINT_CONFIG.coachingSeminar} pts
         </div>
       </div>
 

--- a/pages/Coaching.tsx
+++ b/pages/Coaching.tsx
@@ -248,8 +248,7 @@ const Coaching: React.FC = () => {
                                 individual_coaching: 'bg-blue-100 text-blue-700',
                                 group_coaching: 'bg-green-100 text-green-700',
                                 peer_circles: 'bg-purple-100 text-purple-700',
-                                '2_full_days_seminar': 'bg-orange-100 text-orange-700',
-                                '2_hours_online_seminar': 'bg-teal-100 text-teal-700',
+                                seminar: 'bg-orange-100 text-orange-700',
                             }[session.coaching_type] || 'bg-gray-100 text-gray-600';
 
                             return (

--- a/services/points.ts
+++ b/services/points.ts
@@ -11,16 +11,14 @@ export const DEFAULT_POINT_CONFIG: PointConfig = {
   coachingIndividual: 10,
   coachingGroup: 10,
   coachingPeerCircles: 10,
-  coachingFullDays: 40,
-  coachingOnlineSeminar: 10,
+  coachingSeminar: 10,
 };
 
 const COACHING_TYPE_TO_CONFIG_KEY: Record<CoachingType, keyof PointConfig> = {
   individual_coaching: 'coachingIndividual',
   group_coaching: 'coachingGroup',
   peer_circles: 'coachingPeerCircles',
-  '2_full_days_seminar': 'coachingFullDays',
-  '2_hours_online_seminar': 'coachingOnlineSeminar',
+  seminar: 'coachingSeminar',
 };
 
 export function computeUserPoints(

--- a/types.generated.ts
+++ b/types.generated.ts
@@ -4491,7 +4491,7 @@ export interface components {
          * @example group_coaching
          * @enum {string}
          */
-        CoachingTypeEnum: "individual_coaching" | "group_coaching" | "peer_circles" | "2_full_days_seminar" | "2_hours_online_seminar";
+        CoachingTypeEnum: "individual_coaching" | "group_coaching" | "peer_circles" | "seminar";
         /**
          * @example online
          * @enum {string}

--- a/types.ts
+++ b/types.ts
@@ -88,8 +88,7 @@ export interface PointConfig {
   coachingIndividual: number;     // default 10
   coachingGroup: number;          // default 10
   coachingPeerCircles: number;    // default 10
-  coachingFullDays: number;       // default 40
-  coachingOnlineSeminar: number;  // default 10
+  coachingSeminar: number;        // default 10
 }
 
 export interface PointEntry {
@@ -129,8 +128,7 @@ export const COACHING_TYPE_LABELS: Record<CoachingType, string> = {
   individual_coaching: 'Individual Coaching',
   group_coaching: 'Group Coaching',
   peer_circles: 'Peer Circle Meeting',
-  '2_full_days_seminar': 'Seminar',
-  '2_hours_online_seminar': 'Seminar',
+  seminar: 'Seminar',
 };
 
 export const TRAINING_MODE_LABELS: Record<TrainingMode, string> = {


### PR DESCRIPTION
## Summary
- Merged `2_full_days_seminar` and `2_hours_online_seminar` into a single `seminar` enum value across the entire frontend to match the updated backend API spec

## Changes
- **openapi.yaml + types.generated.ts** — updated `CoachingTypeEnum`
- **types.ts** — updated `COACHING_TYPE_LABELS` and `PointConfig` (`coachingFullDays` + `coachingOnlineSeminar` → `coachingSeminar`)
- **CreateCoachingModal.tsx** — updated `FRONTEND_TO_BACKEND` map and `backendToFront()`, removed unused `isSeminator` variable
- **Coaching.tsx** — updated session type badge class map
- **services/points.ts** — updated `COACHING_TYPE_TO_CONFIG_KEY` and `DEFAULT_POINT_CONFIG`
- **AdminRewards.tsx** — updated activity key maps, state type, dirty check, field list, `CoachingActivityKey` union type

## Test plan
- [ ] Verify coaching session creation with `seminar` type works correctly
- [ ] Verify existing seminar sessions display correctly on Coaching page
- [ ] Verify AdminRewards page loads without errors and seminar point config works
- [ ] Verify points calculation for seminar attendance

🤖 Generated with [Claude Global](https://claude.com/claude-code)