### PR TITLE
feat: integrate delete prospect API and update password change endpoint

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -596,6 +596,90 @@ paths:
   # USERS
   ##############################################################################
 
+  /users/me/password:
+    patch:
+      tags: [Users]
+      summary: Change the authenticated user's password
+      description: >
+        Updates the password for the currently authenticated user. The caller
+        must supply a valid Bearer token. The new password must be at least 6
+        characters and contain at least one uppercase letter, one digit, and
+        one special character.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [newPassword]
+              additionalProperties: false
+              properties:
+                newPassword:
+                  type: string
+                  minLength: 6
+                  description: >
+                    The replacement password. Must be at least 6 characters and
+                    contain at least one uppercase letter, one digit, and one
+                    special (non-alphanumeric) character.
+                  example: "$Test1"
+            example:
+              newPassword: "$Test1"
+      responses:
+        "200":
+          description: Password changed successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [success, message]
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  message:
+                    type: string
+                    example: Password changed successfully
+              example:
+                success: true
+                message: Password changed successfully
+        "400":
+          description: >
+            Bad request. Returned when the request body fails validation —
+            for example when `newPassword` is absent, too short, or does not
+            meet the complexity requirements.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ValidationErrorResponse"
+              example:
+                message: Validation failed
+                errors:
+                  - code: too_small
+                    minimum: 6
+                    type: string
+                    inclusive: true
+                    exact: false
+                    message: Password must be at least 6 characters
+                    path: [newPassword]
+        "401":
+          description: >
+            Unauthorized. Returned when the `Authorization` header is absent,
+            malformed, or contains an invalid token.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: Unauthorized
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
   /users:
     get:
       tags: [Users]
@@ -1855,6 +1939,74 @@ paths:
                 message: Forbidden
         "404":
           description: Not found. Returned when no prospect exists for the given `prospectId`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: Prospect not found
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    delete:
+      tags: [Prospects]
+      summary: Delete a prospect
+      description: >
+        Deletes the prospect identified by prospectId. Requires a valid Bearer token.
+        RLS enforces tenant and agent scoping — if the prospect is not visible to the
+        caller, a 404 is returned (existence is not leaked via 403).
+        Only agents (own prospects) and admins may delete prospects.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: prospectId
+          in: path
+          required: true
+          description: The UUID of the prospect to delete.
+          schema:
+            type: string
+            format: uuid
+            example: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+      responses:
+        "200":
+          description: Prospect deleted successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - success
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+        "401":
+          description: >
+            Unauthorized. Returned when the `Authorization` header is absent,
+            malformed, or contains an invalid token.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: Unauthorized
+        "403":
+          description: >
+            Forbidden. Returned when the authenticated user does not have the
+            `agent` or `admin` role.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                message: Forbidden
+        "404":
+          description: >
+            Not found. Returned when no prospect exists for the given `prospectId`,
+            or the prospect is not visible to the caller due to RLS.
           content:
             application/json:
               schema:
@@ -4265,7 +4417,7 @@ components:
 
     AgentPointsBreakdownItem:
       type: object
-      required: [id, date, category, action, subject, points]
+      required: [id, date, category, action, points]
       properties:
         id:
           type: string
@@ -4287,7 +4439,12 @@ components:
           example: Appointment Set
         subject:
           type: string
-          description: Name of the subject (e.g. prospect) associated with the action.
+          nullable: true
+          description: >
+            Name of the subject (e.g. prospect) associated with the action.
+            Null when the underlying subject has been deleted — e.g. a
+            `prospect_deleted` compensation row references a prospect that
+            no longer exists. Frontends should fall back to the action label.
           example: John Tan
         points:
           type: integer

--- a/pages/PointsHistory.tsx
+++ b/pages/PointsHistory.tsx
@@ -321,10 +321,16 @@ const PointsHistory: React.FC = () => {
                       <tr key={entry.id} className="hover:bg-blue-50 transition-colors">
                         <td className="px-6 py-3 text-sm text-gray-500 whitespace-nowrap">{formatDate(entry.date)}</td>
                         <td className="px-6 py-3 text-sm text-gray-700 font-medium">{entry.action}</td>
-                        <td className="px-6 py-3 text-sm text-gray-600 truncate max-w-[160px]">{entry.subject}</td>
+                        <td className="px-6 py-3 text-sm text-gray-600 truncate max-w-[160px]">
+                          {entry.subject ?? <span className="italic text-gray-400">(deleted prospect)</span>}
+                        </td>
                         <td className="px-6 py-3 text-right">
-                          <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold bg-green-100 text-green-700">
-                            +{entry.points} pts
+                          <span
+                            className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${
+                              entry.points < 0 ? 'bg-rose-100 text-rose-700' : 'bg-green-100 text-green-700'
+                            }`}
+                          >
+                            {entry.points >= 0 ? `+${entry.points}` : entry.points} pts
                           </span>
                         </td>
                       </tr>

--- a/tests/pages/PointsHistory.test.tsx
+++ b/tests/pages/PointsHistory.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+vi.mock('@lottiefiles/react-lottie-player', () => ({
+  Player: () => null,
+}));
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { http, HttpResponse } from 'msw';
+import { server } from '../mocks/server';
+import { loginAs } from '../mocks/auth';
+import PointsHistory from '../../pages/PointsHistory';
+import { AuthProvider } from '../../context/AuthContext';
+import { DataProvider } from '../../context/DataContext';
+
+function renderWithProviders(ui: React.ReactElement) {
+  return render(
+    <MemoryRouter>
+      <AuthProvider>
+        <DataProvider>{ui}</DataProvider>
+      </AuthProvider>
+    </MemoryRouter>
+  );
+}
+
+const BASE = '/api';
+
+const agentPointsFixture = {
+  success: true,
+  data: {
+    total: 1,
+    categories: { prospect: 1, sales: 0, coaching: 0 },
+    breakdown: [
+      {
+        id: 'entry-001',
+        date: '2026-04-01T10:00:00.000Z',
+        category: 'prospect',
+        action: 'Prospect Added',
+        subject: 'Alice Tan',
+        points: 3,
+      },
+      {
+        id: 'entry-002',
+        date: '2026-04-10T12:00:00.000Z',
+        category: 'prospect',
+        action: 'Prospect Deleted',
+        subject: null,
+        points: -3,
+      },
+    ],
+    pagination: { page: 1, limit: 100, total_count: 2, total_pages: 1 },
+  },
+};
+
+describe('PointsHistory', () => {
+  it('renders without crashing for an agent', async () => {
+    loginAs('mdrt_stars_agent');
+    server.use(
+      http.get(`${BASE}/agent-points`, () => HttpResponse.json(agentPointsFixture))
+    );
+
+    const { container } = renderWithProviders(<PointsHistory />);
+    await waitFor(() => expect(container.firstChild).not.toBeNull());
+  });
+
+  it('shows positive-points rows with a "+" prefix in a green badge', async () => {
+    loginAs('mdrt_stars_agent');
+    server.use(
+      http.get(`${BASE}/agent-points`, () => HttpResponse.json(agentPointsFixture))
+    );
+
+    renderWithProviders(<PointsHistory />);
+
+    // Open the Prospect Management history modal (first of three "See Points History →" buttons)
+    await waitFor(() =>
+      expect(screen.getAllByText('See Points History →')[0]).toBeInTheDocument()
+    );
+    await userEvent.click(screen.getAllByText('See Points History →')[0]);
+
+    // Regular row: shows prospect name and "+3 pts" in green
+    await waitFor(() => expect(screen.getByText('Alice Tan')).toBeInTheDocument());
+    const positiveBadge = screen.getByText('+3 pts');
+    expect(positiveBadge).toBeInTheDocument();
+    expect(positiveBadge.className).toMatch(/green/);
+  });
+
+  it('shows prospect_deleted rows with "(deleted prospect)" and a negative red badge', async () => {
+    loginAs('mdrt_stars_agent');
+    server.use(
+      http.get(`${BASE}/agent-points`, () => HttpResponse.json(agentPointsFixture))
+    );
+
+    renderWithProviders(<PointsHistory />);
+
+    await waitFor(() =>
+      expect(screen.getAllByText('See Points History →')[0]).toBeInTheDocument()
+    );
+    await userEvent.click(screen.getAllByText('See Points History →')[0]);
+
+    // Deletion row: shows "(deleted prospect)" fallback
+    await waitFor(() =>
+      expect(screen.getByText('(deleted prospect)')).toBeInTheDocument()
+    );
+
+    // Points badge shows the negative number with no "+" prefix
+    const negativeBadge = screen.getByText('-3 pts');
+    expect(negativeBadge).toBeInTheDocument();
+    expect(negativeBadge.className).toMatch(/rose/);
+    // Must NOT show "+-3 pts"
+    expect(screen.queryByText('+-3 pts')).not.toBeInTheDocument();
+  });
+});

--- a/types.generated.ts
+++ b/types.generated.ts
@@ -577,6 +577,121 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/users/me/password": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Change the authenticated user's password
+         * @description Updates the password for the currently authenticated user. The caller must supply a valid Bearer token. The new password must be at least 6 characters and contain at least one uppercase letter, one digit, and one special character.
+         */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    /**
+                     * @example {
+                     *       "newPassword": "$Test1"
+                     *     }
+                     */
+                    "application/json": {
+                        /**
+                         * @description The replacement password. Must be at least 6 characters and contain at least one uppercase letter, one digit, and one special (non-alphanumeric) character.
+                         * @example $Test1
+                         */
+                        newPassword: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Password changed successfully */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "success": true,
+                         *       "message": "Password changed successfully"
+                         *     }
+                         */
+                        "application/json": {
+                            /** @example true */
+                            success: boolean;
+                            /** @example Password changed successfully */
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Bad request. Returned when the request body fails validation — for example when `newPassword` is absent, too short, or does not meet the complexity requirements. */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "message": "Validation failed",
+                         *       "errors": [
+                         *         {
+                         *           "code": "too_small",
+                         *           "minimum": 6,
+                         *           "type": "string",
+                         *           "inclusive": true,
+                         *           "exact": false,
+                         *           "message": "Password must be at least 6 characters",
+                         *           "path": [
+                         *             "newPassword"
+                         *           ]
+                         *         }
+                         *       ]
+                         *     }
+                         */
+                        "application/json": components["schemas"]["ValidationErrorResponse"];
+                    };
+                };
+                /** @description Unauthorized. Returned when the `Authorization` header is absent, malformed, or contains an invalid token. */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "message": "Unauthorized"
+                         *     }
+                         */
+                        "application/json": components["schemas"]["ErrorResponse"];
+                    };
+                };
+                /** @description Internal server error */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ErrorResponse"];
+                    };
+                };
+            };
+        };
+        trace?: never;
+    };
     "/users": {
         parameters: {
             query?: never;
@@ -1952,7 +2067,87 @@ export interface paths {
             };
         };
         post?: never;
-        delete?: never;
+        /**
+         * Delete a prospect
+         * @description Deletes the prospect identified by prospectId. Requires a valid Bearer token. RLS enforces tenant and agent scoping — if the prospect is not visible to the caller, a 404 is returned (existence is not leaked via 403). Only agents (own prospects) and admins may delete prospects.
+         */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description The UUID of the prospect to delete. */
+                    prospectId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Prospect deleted successfully */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @example true */
+                            success: boolean;
+                        };
+                    };
+                };
+                /** @description Unauthorized. Returned when the `Authorization` header is absent, malformed, or contains an invalid token. */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "message": "Unauthorized"
+                         *     }
+                         */
+                        "application/json": components["schemas"]["ErrorResponse"];
+                    };
+                };
+                /** @description Forbidden. Returned when the authenticated user does not have the `agent` or `admin` role. */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "message": "Forbidden"
+                         *     }
+                         */
+                        "application/json": components["schemas"]["ErrorResponse"];
+                    };
+                };
+                /** @description Not found. Returned when no prospect exists for the given `prospectId`, or the prospect is not visible to the caller due to RLS. */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "message": "Prospect not found"
+                         *     }
+                         */
+                        "application/json": components["schemas"]["ErrorResponse"];
+                    };
+                };
+                /** @description Internal server error */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ErrorResponse"];
+                    };
+                };
+            };
+        };
         options?: never;
         head?: never;
         patch?: never;
@@ -4451,10 +4646,10 @@ export interface components {
              */
             action: string;
             /**
-             * @description Name of the subject (e.g. prospect) associated with the action.
+             * @description Name of the subject (e.g. prospect) associated with the action. Null when the underlying subject has been deleted — e.g. a `prospect_deleted` compensation row references a prospect that no longer exists. Frontends should fall back to the action label.
              * @example John Tan
              */
-            subject: string;
+            subject?: string | null;
             /**
              * @description Number of points awarded for this transaction.
              * @example 3


### PR DESCRIPTION
This pull request introduces two new API endpoints and improves how deleted prospects are represented in the points history UI and API. It also adds comprehensive tests for the updated points history display. The most important changes are summarized below:

---

**API Additions:**

* Added a new `PATCH /users/me/password` endpoint to allow authenticated users to change their password, with validation and appropriate error responses. [[1]](diffhunk://#diff-d910ba2ef878f7db0223a966b81c8b3f3b65027bb39e4431bb05140171eece39R599-R682) [[2]](diffhunk://#diff-0680bcb5cb410ff8c8f4dedf84f268ebeefc6e287a0d069a464909d288bb46e6R580-R694)
* Added a new `DELETE /prospects/{prospectId}` endpoint to allow agents and admins to delete prospects, with role-based access control and clear error handling for unauthorized or forbidden actions. [[1]](diffhunk://#diff-d910ba2ef878f7db0223a966b81c8b3f3b65027bb39e4431bb05140171eece39R1954-R2021) [[2]](diffhunk://#diff-0680bcb5cb410ff8c8f4dedf84f268ebeefc6e287a0d069a464909d288bb46e6L1955-R2150)

**API Schema and Type Improvements:**

* Updated the `AgentPointsBreakdownItem` schema: the `subject` field is now nullable, and its description clarifies that it will be null if the underlying subject (e.g., prospect) has been deleted. Frontends should fall back to the action label in such cases. [[1]](diffhunk://#diff-d910ba2ef878f7db0223a966b81c8b3f3b65027bb39e4431bb05140171eece39L4268-R4420) [[2]](diffhunk://#diff-d910ba2ef878f7db0223a966b81c8b3f3b65027bb39e4431bb05140171eece39L4290-R4447) [[3]](diffhunk://#diff-0680bcb5cb410ff8c8f4dedf84f268ebeefc6e287a0d069a464909d288bb46e6L4454-R4652)

**Frontend Improvements:**

* Updated `PointsHistory.tsx` to display "(deleted prospect)" in italics and gray when the `subject` is null, and to show negative points in a red badge (using the `rose` color), while positive points remain green.

**Testing:**

* Added new tests for `PointsHistory` to verify that deleted prospects are displayed correctly and that points badges use the correct color and sign formatting for positive and negative values.